### PR TITLE
Limit process count and assign colors

### DIFF
--- a/src/main/java/org/example/proyectoso/HelloController.java
+++ b/src/main/java/org/example/proyectoso/HelloController.java
@@ -261,8 +261,9 @@ public class HelloController implements Initializable {
         int tiempo = 0;
 
         while (!pendientes.isEmpty() && tiempo < TIEMPO_TOTAL) {
+            int currentTime = tiempo;
             List<Proceso> disponibles = pendientes.stream()
-                    .filter(p -> p.getTiempoLlegada() <= tiempo)
+                    .filter(p -> p.getTiempoLlegada() <= currentTime)
                     .toList();
 
             if (disponibles.isEmpty()) {

--- a/src/main/java/org/example/proyectoso/models/Proceso.java
+++ b/src/main/java/org/example/proyectoso/models/Proceso.java
@@ -1,6 +1,8 @@
 package org.example.proyectoso.models;
 
 
+import javafx.scene.paint.Color;
+
 public class Proceso {
     // Identificación
     private static int contadorId = 1;
@@ -24,6 +26,9 @@ public class Proceso {
 
     // Para Round Robin
     private int quantumRestante;
+
+    // Color distintivo para la visualización
+    private Color color;
 
 
     public Proceso(String nombre, int duracion, int tamanoMemoria, int tiempoLlegada) {
@@ -201,6 +206,14 @@ public class Proceso {
 
     public int getQuantumRestante() {
         return quantumRestante;
+    }
+
+    public Color getColor() {
+        return color;
+    }
+
+    public void setColor(Color color) {
+        this.color = color;
     }
 
     public long getTiempoInicioEjecucion() {


### PR DESCRIPTION
## Summary
- give each `Proceso` a color field
- maintain a palette of colors in the controller
- allow adding up to six processes and color rows accordingly
- return a color to the palette when removing
- add basic SJF simulation that paints the Gantt grid when starting

## Testing
- `javac src/main/java/org/example/proyectoso/HelloController.java` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68549505f20c832a84f08dfe69c95af3