### PR TITLE
Fix swapping activation on memory release

### DIFF
--- a/src/main/java/org/example/proyectoso/HelloController.java
+++ b/src/main/java/org/example/proyectoso/HelloController.java
@@ -704,7 +704,16 @@ public class HelloController implements Initializable {
                                 actualizarEstadoProceso(proceso, EstadoProceso.TERMINADO);
                                 proceso.marcarFinalizacion(tiempoActual + 1);
                                 coresALiberar.add(coreId);
-                                memoria.liberarMemoria(proceso);
+                                List<Proceso> liberados = memoria.liberarMemoria(proceso);
+                                for (Proceso p : liberados) {
+                                    if (!tiempoRestanteProceso.containsKey(p)) {
+                                        tiempoRestanteProceso.put(p, p.getDuracion());
+                                    }
+                                    procesosListos.add(p);
+                                    actualizarEstadoProceso(p, EstadoProceso.LISTO);
+                                    System.out.println("🆘 t=" + tiempoActual + ": Proceso " + p.getId() +
+                                            " salió del SWAP tras liberar memoria y agregado a lista de listos");
+                                }
                                 System.out.println("✅ t=" + tiempoActual + ": Proceso " + proceso.getId() + " terminado en Core-" + coreId + " (RR)");
                                 actualizarVisualizacionMemoria();
                             } else if (quantumRestante <= 0) {
@@ -721,7 +730,16 @@ public class HelloController implements Initializable {
                                 actualizarEstadoProceso(proceso, EstadoProceso.TERMINADO);
                                 proceso.marcarFinalizacion(tiempoActual + 1);
                                 coresALiberar.add(coreId);
-                                memoria.liberarMemoria(proceso);
+                                List<Proceso> liberados = memoria.liberarMemoria(proceso);
+                                for (Proceso p : liberados) {
+                                    if (!tiempoRestanteProceso.containsKey(p)) {
+                                        tiempoRestanteProceso.put(p, p.getDuracion());
+                                    }
+                                    procesosListos.add(p);
+                                    actualizarEstadoProceso(p, EstadoProceso.LISTO);
+                                    System.out.println("🆘 t=" + tiempoActual + ": Proceso " + p.getId() +
+                                            " salió del SWAP tras liberar memoria y agregado a lista de listos");
+                                }
                                 System.out.println("✅ t=" + tiempoActual + ": Proceso " + proceso.getId() + " terminado en Core-" + coreId + " (SJF)");
                                 actualizarVisualizacionMemoria();
                             }

--- a/src/main/java/org/example/proyectoso/memoria/Memoria.java
+++ b/src/main/java/org/example/proyectoso/memoria/Memoria.java
@@ -80,8 +80,9 @@ public class Memoria {
         }
     }
 
-    public boolean liberarMemoria(Proceso proceso) {
+    public List<Proceso> liberarMemoria(Proceso proceso) {
         synchronized (lock) {
+            List<Proceso> procesosLiberados = new ArrayList<>();
             
             for (BloqueMemoria bloque : bloques) {
                 if (bloque.isOcupado() &&
@@ -99,14 +100,14 @@ public class Memoria {
                     calcularFragmentacion();
 
                     
-                    procesarSwapping();
+                    procesosLiberados.addAll(procesarSwapping());
 
-                    return true;
+                    return procesosLiberados;
                 }
             }
 
             System.out.println("⚠️ No se encontró memoria para liberar del Proceso " + proceso.getId());
-            return false;
+            return procesosLiberados;
         }
     }
 
@@ -168,13 +169,15 @@ public class Memoria {
     }
 
 
-    private void procesarSwapping() {
+    private List<Proceso> procesarSwapping() {
         List<Proceso> procesosLiberados = swapping.procesarCola(this);
 
         if (!procesosLiberados.isEmpty()) {
             System.out.println("🔄 " + procesosLiberados.size() +
                     " proceso(s) salieron del swapping");
         }
+
+        return procesosLiberados;
     }
 
 


### PR DESCRIPTION
## Summary
- return processes released from swap when freeing memory
- enqueue those processes in `HelloController` when a process finishes

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686b5e3fb22c832ab1a3e7dd3d831855