### PR TITLE
Fix memory release handling in schedulers

### DIFF
--- a/src/main/java/org/example/proyectoso/HelloController.java
+++ b/src/main/java/org/example/proyectoso/HelloController.java
@@ -274,6 +274,8 @@ public class HelloController implements Initializable {
                 break;
         }
 
+        planificador.setCpu(cpu);
+        planificador.setMemoria(memoria);
         manejoProcesos.setPlanificador(planificador);
     }
 

--- a/src/main/java/org/example/proyectoso/planificacion/Planificacion.java
+++ b/src/main/java/org/example/proyectoso/planificacion/Planificacion.java
@@ -1,5 +1,6 @@
 package org.example.proyectoso.planificacion;
 import org.example.proyectoso.models.*;
+import org.example.proyectoso.memoria.Memoria;
 
 import java.util.List;
 
@@ -10,6 +11,8 @@ public abstract class Planificacion {
 
     
     protected CPU cpu;
+
+    protected Memoria memoria;
 
     
     protected volatile boolean ejecutando;
@@ -32,6 +35,12 @@ public abstract class Planificacion {
     public void setCpu(CPU cpu) {
         synchronized (lock) {
             this.cpu = cpu;
+        }
+    }
+
+    public void setMemoria(Memoria memoria) {
+        synchronized (lock) {
+            this.memoria = memoria;
         }
     }
 

--- a/src/main/java/org/example/proyectoso/planificacion/RoundRobin.java
+++ b/src/main/java/org/example/proyectoso/planificacion/RoundRobin.java
@@ -139,6 +139,9 @@ public class RoundRobin extends Planificacion {
             if (terminado) {
                 proceso.setEstado(EstadoProceso.TERMINADO);
                 System.out.println("✅ Proceso " + proceso.getId() + " completado");
+                if (memoria != null) {
+                    memoria.liberarMemoria(proceso);
+                }
             } else {
                 proceso.setEstado(EstadoProceso.LISTO);
                 System.out.println("⏸️ Proceso " + proceso.getId() + " suspendido (quantum agotado)");

--- a/src/main/java/org/example/proyectoso/planificacion/SJF.java
+++ b/src/main/java/org/example/proyectoso/planificacion/SJF.java
@@ -188,6 +188,9 @@ public class SJF extends Planificacion {
             if (proceso.haTerminado()) {
                 proceso.setEstado(EstadoProceso.TERMINADO);
                 System.out.println("✅ Proceso " + proceso.getId() + " completado");
+                if (memoria != null) {
+                    memoria.liberarMemoria(proceso);
+                }
             }
 
         } finally {
@@ -235,6 +238,9 @@ public class SJF extends Planificacion {
             if (proceso.haTerminado()) {
                 proceso.setEstado(EstadoProceso.TERMINADO);
                 System.out.println("✅ Proceso " + proceso.getId() + " completado");
+                if (memoria != null) {
+                    memoria.liberarMemoria(proceso);
+                }
             } else {
                 proceso.setEstado(EstadoProceso.LISTO);
                 System.out.println("⏸️ Proceso " + proceso.getId() + " suspendido");


### PR DESCRIPTION
## Summary
- connect schedulers with memory module
- free memory of completed processes in SJF and Round Robin
- expose memory setter in `Planificacion`
- configure the planificador with CPU and memory from the controller

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686b62516b54832a8daab682977938b1